### PR TITLE
Replaces hardcoded "Article" header for article listing with optional parameter "articlesLabel" on config file

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -65,7 +65,7 @@
           <div class="p-5 bg-white">
               <h2>{{ .Title }}</h2>
               <div class="bg-gray p-4">
-                  <h3 class="mt-0">Article</h3>
+                  <h3 class="mt-0">{{if .Language.Params.articlesLabel }} {{ .Language.Params.articlesLabel }} {{ else }} "Articles" {{ end }}</h3>
                   <ul class="list-unstyled">
                     {{ range .Data.Pages }}
                     <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>


### PR DESCRIPTION
When listing articles for a Topic, the list was always labeled "Article".
If "articlesLabel" is set on [[Languages.<languageCode>]] section of site's config file,
it is used as Header for the listing of articles of the topic.
If it is not set, "Articles" is used.