### PR TITLE
turkish character bug fix on faq shortcode

### DIFF
--- a/layouts/shortcodes/faq.html
+++ b/layouts/shortcodes/faq.html
@@ -1,29 +1,12 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
 
-{{ if .Get 1 }}
-  <div class="card mb-4 rounded-0 shadow border-0">
-    <div class="card-header rounded-0 bg-white border p-0 border-0">
-      <a class="card-link h4 d-flex tex-dark mb-0 py-3 px-4 justify-content-between" data-toggle="collapse"
-        href="#{{ .Get 1 }}">
-        <span>{{ .Get 0 | markdownify }}</span> <i class="ti-plus text-primary text-right"></i>
-        
-      </a>
-    </div>
-    <div id="{{ .Get 1 }}" class="collapse" data-parent="#accordion">
-      <div class="card-body font-secondary text-color">{{ .Inner | markdownify }}</div>
-    </div>
+<div class="card mb-4 rounded-0 shadow border-0">
+  <div class="card-header rounded-0 bg-white border p-0 border-0">
+    <a class="card-link h4 d-flex tex-dark mb-0 py-3 px-4 justify-content-between" data-toggle="collapse" href="#{{ .Get 0 | sha1 }}">
+      <span>{{ .Get 0 | markdownify }}</span> <i class="ti-plus text-primary text-right"></i>
+    </a>
   </div>
-{{else}}
-  <div class="card mb-4 rounded-0 shadow border-0">
-    <div class="card-header rounded-0 bg-white border p-0 border-0">
-      <a class="card-link h4 d-flex tex-dark mb-0 py-3 px-4 justify-content-between" data-toggle="collapse"
-        href="#{{ .Get 0 | anchorize }}">
-        <span>{{ .Get 0 | markdownify }}</span> <i class="ti-plus text-primary text-right"></i>
-        
-      </a>
-    </div>
-    <div id="{{ .Get 0 | anchorize }}" class="collapse" data-parent="#accordion">
-      <div class="card-body font-secondary text-color">{{ .Inner | markdownify }}</div>
-    </div>
+  <div id="{{ .Get 0 | sha1 }}" class="collapse" data-parent="#accordion">
+    <div class="card-body font-secondary text-color">{{ .Inner | markdownify }}</div>
   </div>
-{{end}}
+</div>

--- a/layouts/shortcodes/faq.html
+++ b/layouts/shortcodes/faq.html
@@ -1,12 +1,29 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
 
-<div class="card mb-4 rounded-0 shadow border-0">
-  <div class="card-header rounded-0 bg-white border p-0 border-0">
-    <a class="card-link h4 d-flex tex-dark mb-0 py-3 px-4 justify-content-between" data-toggle="collapse" href="#{{ .Get 0 | anchorize }}">
-      <span>{{ .Get 0 | markdownify }}</span> <i class="ti-plus text-primary text-right"></i>
-    </a>
+{{ if .Get 1 }}
+  <div class="card mb-4 rounded-0 shadow border-0">
+    <div class="card-header rounded-0 bg-white border p-0 border-0">
+      <a class="card-link h4 d-flex tex-dark mb-0 py-3 px-4 justify-content-between" data-toggle="collapse"
+        href="#{{ .Get 1 }}">
+        <span>{{ .Get 0 | markdownify }}</span> <i class="ti-plus text-primary text-right"></i>
+        
+      </a>
+    </div>
+    <div id="{{ .Get 1 }}" class="collapse" data-parent="#accordion">
+      <div class="card-body font-secondary text-color">{{ .Inner | markdownify }}</div>
+    </div>
   </div>
-  <div id="{{ .Get 0 | anchorize }}" class="collapse" data-parent="#accordion">
-    <div class="card-body font-secondary text-color">{{ .Inner | markdownify }}</div>
+{{else}}
+  <div class="card mb-4 rounded-0 shadow border-0">
+    <div class="card-header rounded-0 bg-white border p-0 border-0">
+      <a class="card-link h4 d-flex tex-dark mb-0 py-3 px-4 justify-content-between" data-toggle="collapse"
+        href="#{{ .Get 0 | anchorize }}">
+        <span>{{ .Get 0 | markdownify }}</span> <i class="ti-plus text-primary text-right"></i>
+        
+      </a>
+    </div>
+    <div id="{{ .Get 0 | anchorize }}" class="collapse" data-parent="#accordion">
+      <div class="card-body font-secondary text-color">{{ .Inner | markdownify }}</div>
+    </div>
   </div>
-</div>
+{{end}}


### PR DESCRIPTION
When i using faq shortcode, i saw turkish characters(like "ı", "ç") broke accordion system. I solved this problem by taking the key in another parameter. Unless parameter, everything is same.