### PR TITLE
Added Hugo internal templates for Opengraph support

### DIFF
--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -67,6 +67,33 @@
             <a class="nav nav-next" href="{{.Permalink }}"> <span class="d-none d-md-block">{{.Title}}</span><i class="ti-arrow-right ml-2"></i></a>
             {{end}}
           </nav>
+
+          <section class="my-3 py-3" id="related-articles">
+            {{$c := .Section}}
+            {{$p := .Params.Categories}} 
+            <h5 class="text-center">Related Articles</h5>
+            <div class="row">
+                {{ range $key, $taxonomy := .Site.Taxonomies.categories }}
+                {{if eq $key $p}}
+                    {{ range  $taxonomy.Pages}}
+                    <a href="{{ .Permalink}}">
+                      <div class="col-sm-3">
+                        <div class="card" style="width: 12rem;">
+                          <img class="card-img-top" {{ with .Params.image }} src="{{ . }}"{{ end }} alt="{{ .Params.Title }}">
+                          <div class="card-body">
+                            <h5 class="card-title">{{ .Title }}</h5>
+                            <h6 class="card-subtitle mb-2 text-muted">{{.Params.Categories}}</h6>
+                            <h6 class="card-subtitle mb-2 text-muted">{{.Section}}</h6>
+                          </div>
+                        </div>
+                      </div>     
+                    </a>
+                    {{ end }}
+                {{ end }}
+                {{end}}
+              </div>
+          </section>
+
         </div>
       </div>
     </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,6 +3,8 @@
   <title>{{ .Title }}</title>
 
   {{ hugo.Generator }}
+  {{ template "_internal/opengraph.html" . }}
+  {{ template "_internal/twitter_cards.html" . }}
 
   {{ "<!-- mobile responsive meta -->" | safeHTML }}
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">


### PR DESCRIPTION
# Summary

This PR adds support for Open Graph images, article metadata and Twitter cards.

# Background

**Is your feature request related to a problem? Please describe**:
An issue was raised in a repository that has this repository as a sub-module. @jwflory
[Issue Here](https://github.com/unicef/inventory/issues/18)
It concerns adding functionality for open graph images and twitter cards.


# Details
Hugo already provides support for this in its templates which i have included in the partials.head file.


# Outcome
This PR lets users be able to use basic Front Matter keywords to be able to add things like images, tags and descriptions to their Metatags.
![opengraph](https://user-images.githubusercontent.com/40151808/116456214-39aca380-a81f-11eb-9f8e-5ab3df95b4cc.png)


